### PR TITLE
Update PS2SDK.md

### DIFF
--- a/pages/ps2/PS2SDK.md
+++ b/pages/ps2/PS2SDK.md
@@ -87,9 +87,10 @@ SDK Version | Publicly Leaked? | Notes
 2.8.0 | No | `Fatal Frame 2`
 2.8.1 | No | `Bloody Roar` MCMAN.IRX has `PSIImcman 2810`
 3.0.0 | (publicly leaked with 2.7 Docs; maybe incomplete) | `Resident Evil 4` **Nov 2003**
-3.0.1 | No | `24 The Game`
+3.0.1 | No | `24 The Game` **Mar 2004**
 3.0.2 | publicly leaked maybe incomplete | `Shadow of the Colossus (PAL)` **Jul 2004**
 3.0.3 | publicly leaked **complete** | **Jun 2005**
+3.0.4 | No | `King of Fighters XI (NTSC-J)` NTGUI.IRX has `PsIIntgui2  3040`
 3.1.0 | No | 
 
 


### PR DESCRIPTION
3.0.1 release date can be taken from 3.0.2 publicly leaked from file readme-3.0.1.txt
3.0.4 can be found in King of Fighters XI, The [NTSC-J] [SLPS-25660] ntgui.irx