### PR TITLE
Add info about RE4 GC debug symbols

### DIFF
--- a/pages/gamecube/GamecubeDebugSymbols.md
+++ b/pages/gamecube/GamecubeDebugSymbols.md
@@ -147,6 +147,7 @@ Prototype games are even more likely to contain debug symbols as they are intend
 Game Name | Map File | Number of Symbols | Genre | Notes
 --- | --- | --- | --- | ---
 NFS Underground (Preview 10-09-2003 Console+ 26669 - 010) | Speed.elf | **9,604** | Racing | Uses SNSystems Library + Debugger
+Resident Evil 4 (Debug Build) | Bio4.\*.SYM | **10,380+** | Action | Contains SYM files for the main executable & the REL overlay files (some RELs are stored inside DRS containers) - unknown what created the SYM files, but a [parser](https://github.com/emoose/re4-research/blob/master/re4sym.cpp) is available.
 
 ---
 # Other Notes


### PR DESCRIPTION
Mentioned the RE4 debug build symbols on the GC symbols page, couldn't find much info about the SYM files it uses, but fortunately they weren't too difficult to parse (if anyone knows what created them or any other games that use them, please let me know!)

(maybe should have mentioned in that edit, but the GC symbols have way more function names included compared to the RE4 symbols mentioned on the PS2 page - did end up writing [an IDA loader](https://github.com/emoose/re4-research/blob/master/prodg-rel.py) for the PS2 files to get as many symbols from it as I could though, which came in useful for naming things that were only added in PS2 release)
