### PR TITLE
Add info about Neon Genesis Evangelion 2 to PS2SDK.md

### DIFF
--- a/pages/ps2/PS2SDK.md
+++ b/pages/ps2/PS2SDK.md
@@ -82,7 +82,7 @@ SDK Version | Publicly Leaked? | Notes
 2.5.4 | No | `The Mark of Kri`
 2.5.5 | No | `Virtual Fighter 4 Evolution (Korean version)`
 2.7.0 | Docs leaked | **March 2003**
-2.7.1 | No | `Jak II`
+2.7.1 | No | `Jak II` | `Neon Genesis Evangelion 2 (NTCS-J)` MCMAN.IRX has `PsIImcman   2710`
 2.7.2 | No | 
 2.8.0 | No | `Fatal Frame 2`
 2.8.1 | No | `Bloody Roar` MCMAN.IRX has `PSIImcman 2810`


### PR DESCRIPTION
Found by using "strings" command in game files.