### PR TITLE
Add section on .mdebug to PS2 unstripped binaries article

### DIFF
--- a/pages/ps2/Ps2UnstrippedBinaries.md
+++ b/pages/ps2/Ps2UnstrippedBinaries.md
@@ -859,8 +859,8 @@ Xenosaga Episode II - Jenseits von Gut und Boese (Europe) | `Monolith Soft` | 24
 # PS2 ELF Format
 Unlike most other games consoles, the PS2 executables are standard ELF files without any sort of encryption or compression. This means the format is very well documented around the web and also most tool that support ELF executables should work.
 
-## Segments
-The ELF file format contains a bunch of segments, most are common across different platforms.
+## Sections
+The ELF file format contains a bunch of sections, most are common across different platforms.
 
 Name | Description
 --- | ---
@@ -876,6 +876,12 @@ Name | Description
 .text | Contains the Code (functions)
 abs | Absolute Symbols
 extern | External Symbols
+
+## .mdebug Section
+
+Some PS2 executable files contain a .mdebug section, which is an extended symbol table intended for use with certain versions of gdb. It contains rich debugging information in the STABS format such as complete data type definitions, function information (parameters, local variables, the return type), global variables, and more.
+
+The [Chaos Compiler Collection](https://github.com/chaoticgd/ccc) can be used to extract this information, either as C++ code or as a JSON file that can then be imported into [Ghidra](https://ghidra-sre.org/) using the provided extension.
 
 ## .sndata Tool
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Woah! This is awesome, anyone interested in <a href="https://twitter.com/hashtag/Playstation2?src=hash&amp;ref_src=twsrc%5Etfw">#Playstation2</a> reversing should check this out <a href="https://t.co/W5WgaCbLgF">https://t.co/W5WgaCbLgF</a></p>&mdash; RetroReversing.com - Reverse Retro Games (@RetroReversing) <a href="https://twitter.com/RetroReversing/status/1307248565622845442?ref_src=twsrc%5Etfw">September 19, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
This adds some information to the PS2 article on unstripped binaries about .mdebug symbol tables present on many PS2 games compiled with the official SDK:

> Some PS2 executable files contain a .mdebug section, which is an extended symbol table intended for use with certain versions of gdb. It contains rich debugging information in the STABS format such as complete data type definitions, function information (parameters, local variables, the return type), global variables, and more.

It also plugs my tool [ccc](https://github.com/chaoticgd/ccc) which is the only piece of software I know of that can extract all this information. It is already being used by multiple modding communities, but I thought since retroReversing is ranked so highly in search results that including a reference to it here might help advertise it to people who might benifit from it. There have been a number of earlier projects by various people trying to dump this section, but to my knowledge they're all not working and abandoned (I don't blame the authors, STABS is a ridiculous format).

If you want an example of a game to test so that you can verify this information yourself the US retail release of Fatal Frame has .mdebug symbols.