### PR TITLE
Ps2UnstrippedBinaries: add prototypes section

### DIFF
--- a/pages/consoles/ps2/Ps2UnstrippedBinaries.md
+++ b/pages/consoles/ps2/Ps2UnstrippedBinaries.md
@@ -828,6 +828,7 @@ Prototype games are even more likely to contain debug symbols as they are intend
 Game Name | Map File | Notes
 --- | --- | ---
 Resident Evil 4 (Review, Aug 27 2005) | SLPS_000.00 | .mdebug section includes functions/structures for the main executable.
+Silent Hill 2 (E3 prototype, May 1 2001) | SLPM_123.45 | .debug section includes functions/structures for both main executable & per-level overlays.
 Silent Hill 2 (0.10 prototype, Jul 13 2001) | SLUS_202.28 | .debug section includes functions/structures for both main executable & per-level overlays.
 Silent Hill 4 (E3 prototype, Apr 16 2004) | SLUS_208.73 | .debug section includes functions/structures for both main executable & per-level overlays.
 

--- a/pages/consoles/ps2/Ps2UnstrippedBinaries.md
+++ b/pages/consoles/ps2/Ps2UnstrippedBinaries.md
@@ -822,6 +822,16 @@ eJay ClubWorld - The Music Making Experience (Europe) | SLES-50933 | 2002-07-19 
 eJay Clubworld - The Music Making Experience (USA) | SLUS-20525 | 2002-12-11 | 
 
 ---
+# PS2 Prototypes with Debug Symbols
+Prototype games are even more likely to contain debug symbols as they are intended for either testing or journalistic usage, thus having the symbols available would help the developers fix bugs before the final retail release. The table below is an incomplete list of prototypes that have debug symbols, if you know any more please let us know!
+
+Game Name | Map File | Notes
+--- | --- | ---
+Resident Evil 4 (Review, Aug 27 2005) | SLPS_000.00 | .mdebug section includes functions/structures for the main executable.
+Silent Hill 2 (0.10 prototype, Jul 13 2001) | SLUS_202.28 | .debug section includes functions/structures for both main executable & per-level overlays.
+Silent Hill 4 (E3 prototype, Apr 16 2004) | SLUS_208.73 | .debug section includes functions/structures for both main executable & per-level overlays.
+
+---
 # PS2 Demos with Debug Symbols
 If your game is not listed in the retail game list above then fear not, there is still a chance that debug symbols are available for a demo of the game. We have a separate page listing all the PS2 Demos with Debug Symbols.
 


### PR DESCRIPTION
There didn't seem to be a section for PS2 protos with symbols so copied the part from GC page over to it, only added 4 protos so far that I know have useful symbols, but AFAIK there's still a ton that aren't mentioned here yet.

(sadly another great site that used to list games with symbols included seems to have been taken down pretty recently, could have helped fill in a lot here ;_;)